### PR TITLE
Remove PPA method

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,3 @@
 ---
-java_deb_method: apt # apt or ppa
-
-java_deb_apt_package: openjdk-8-jdk
-
-java_deb_ppa: ppa:linuxuprising/java
-java_deb_ppa_package: oracle-java11-installer # java11 or java12
-java_deb_ppa_question: shared/accepted-oracle-license-v1-2
-
+java_apt_package: openjdk-8-jdk
 java_yum_package: java-1.8.0-openjdk

--- a/tasks/java_install.yml
+++ b/tasks/java_install.yml
@@ -1,33 +1,12 @@
 ---
-- name: Automatically accept the Oracle License for PPA (Ubuntu/Debian)
-  debconf:
-    name: "{{ java_deb_ppa_package }}"
-    question: "{{ java_deb_ppa_question }}"
-    value: 'true'
-    vtype: 'select'
-  when:
-    - ansible_os_family == 'Debian'
-    - java_deb_method == 'ppa'
-
-- name: Install Java APT package (Ubuntu/Debian)
+- name: Install Java package (Ubuntu/Debian)
   apt:
-    name: "{{ java_deb_apt_package }}"
+    name: "{{ java_apt_package }}"
     state: present
     update_cache: yes
-  when:
-    - ansible_os_family == 'Debian'
-    - java_deb_method == "apt"
+  when: ansible_os_family == 'Debian'
 
-- name: Install Java PPA package (Ubuntu/Debian)
-  apt:
-    name: "{{ java_deb_ppa_package }}"
-    state: present
-    update_cache: yes
-  when:
-    - ansible_os_family == 'Debian'
-    - java_deb_method == 'ppa'
-
-- name: Install Java (CentOS/RHEL)
+- name: Install Java package (CentOS/RHEL)
   yum:
     name: "{{ java_yum_package }}"
     state: present

--- a/tasks/java_pre.yml
+++ b/tasks/java_pre.yml
@@ -1,7 +1,1 @@
 ---
-- name: Add Java PPA (Ubuntu/Debian)
-  apt_repository:
-    repo: "{{ java_deb_ppa }}"
-  when:
-    - ansible_os_family == 'Debian'
-    - java_deb_method == 'ppa'


### PR DESCRIPTION
Since Java 11 PPA is required to manually download tarball to be able to install. We'll streamlined the playbook to just install OpenJDK via APT instead.